### PR TITLE
docs: change link from ieee to arxiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 - SWE-agent: Agent-Computer Interfaces Enable Automated Software Engineering [2024-NeurIPS] [[📄 paper](https://arxiv.org/abs/2405.15793)] [[🔗 repo](https://github.com/SWE-agent/SWE-agent)]
 
 ## 🤖 Repo-Level Code Completion
-- Enhancing Project-Specific Code Completion by Inferring Internal API Information [2025-TSE-EarlyAccess] [[📄 paper](https://ieeexplore.ieee.org/abstract/document/11096713)] [[🔗 repo](https://github.com/ZJU-CTAG/InferCom)]
+- Enhancing Project-Specific Code Completion by Inferring Internal API Information [[📄 paper](https://www.arxiv.org/abs/2507.20888)] [[🔗 repo](https://github.com/ZJU-CTAG/InferCom)]
 
 - CodeRAG: Supportive Code Retrieval on Bigraph for Real-World Code Generation [2025-04-arXiv] [[📄 paper](https://arxiv.org/abs/2504.10046)]
 


### PR DESCRIPTION
for Enhancing Project-Specific Code Completion by Inferring Internal API Information paper

link appears to be more recent as well