### PR TITLE
Add SWE Atlas, SWE-QA-Pro, GitTaskBench to 🔍 Repo-Level Code QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,11 @@
 - RepoChat: An LLM-Powered Chatbot for GitHub Repository Question-Answering [MSR-2025] [[🔗 repo](https://2025.msrconf.org/details/msr-2025-data-and-tool-showcase-track/35/RepoChat-An-LLM-Powered-Chatbot-for-GitHub-Repository-Question-Answering)]
 
 
+- SWE Atlas: Benchmarking Coding Agents Beyond Issue Resolution [2026-05-arXiv] [[📄 paper](https://arxiv.org/abs/2605.08366)] [[🔗 repo](https://github.com/scaleapi/SWE-Atlas)]
 - FastCode: Fast and Cost-Efficient Code Understanding and Reasoning [2026-03-arXiv] [[📄 paper](https://arxiv.org/abs/2603.01012)]
+- SWE-QA-Pro: A Representative Benchmark and Scalable Training Recipe for Repository-Level Code Understanding [2026-ACL] [[📄 paper](https://arxiv.org/abs/2603.16124)] [[🔗 repo](https://github.com/TIGER-AI-Lab/SWE-QA-Pro)]
 - SWE-QA: Can Language Models Answer Repository-level Code Questions? [2025-09-arXiv] [[📄 paper](https://arxiv.org/abs/2509.14635)] [[🔗 repo](https://github.com/peng-weihan/SWE-QA-Bench)]
+- GitTaskBench: A Benchmark for Code Agents Solving Real-World Tasks Through Code Repository Leveraging [2025-08-arXiv] [[📄 paper](https://arxiv.org/abs/2508.18993)] [[🔗 repo](https://github.com/QuantaAlpha/GitTaskBench)]
 - Decompositional Reasoning for Graph Retrieval with Large Language Models [2025-06-arXiv] [[📄 paper](https://arxiv.org/abs/2506.13380)]
 - LongCodeBench: Evaluating Coding LLMs at 1M Context Windows [2025-05-arXiv] [[📄 paper](https://arxiv.org/pdf/2505.07897)]
 - LocAgent: Graph-Guided LLM Agents for Code Localization [2025-03-arXiv] [[📄 paper](https://arxiv.org/abs/2503.09089)] [[🔗 repo](https://github.com/gersteinlab/LocAgent)]


### PR DESCRIPTION
## Summary

Adds 3 recent repository-level QA / agent benchmarks to the 🔍 Repo-Level Code QA section, inserted in reverse-chronological order to match existing convention.

- **SWE Atlas** (Scale AI, arXiv 2605.08366, May 2026) — 3-workflow benchmark (Codebase QnA, Test Writing, Refactoring) with 284 expert-authored tasks across 18 active OSS repos. [GitHub](https://github.com/scaleapi/SWE-Atlas)
- **SWE-QA-Pro** (TIGER-AI-Lab, arXiv 2603.16124, ACL 2026) — Long-tail repo coverage + difficulty-calibrated; SFT + RLAIF training recipe. Follow-up to SWE-QA. [GitHub](https://github.com/TIGER-AI-Lab/SWE-QA-Pro)
- **GitTaskBench** (arXiv 2508.18993, Aug 2025) — 54 real-world tasks × 7 modalities × 7 domains; introduces α-value cost-aware metric. [GitHub](https://github.com/QuantaAlpha/GitTaskBench)