### PR TITLE
Add function-aware FIM mid-training work

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 ## 💥 Repo-Level Issue Resolution
 - LLM Agents Can See Code Repositories [2026-ASE] [[📄 paper](https://arxiv.org/abs/2606.14061)] [[🔗 repo](https://github.com/cslsolow/SeeRepo)]
+- Function-Aware Fill-in-the-Middle as Mid-Training for Coding Agent Foundation Models [2026-07-arXiv] [[📄 paper](https://arxiv.org/abs/2607.12463)] [[🔗 repo](https://github.com/TIGER-AI-Lab/FIM-Midtraining)]
 - Know Before Fix: QA-Driven Repository Knowledge Acquisition for Software Issue Resolution [2026-07-arXiv] [[📄 paper](https://arxiv.org/abs/2607.11111)] [[🔗 repo](https://github.com/LionLin2003/ACQUIRE)]
 - DeNovoSWE: Scaling Long-Horizon Environments for Generating Entire Repositories from Scratch [2026-06-arXiv] [[📄 paper](https://arxiv.org/abs/2606.10728)] [[🔗 repo](https://github.com/AweAI-Team/DeNovoSWE)]
 - SWE-AGILE: A Software Agent Framework for Efficiently Managing Dynamic Reasoning Context [2026-ACL-Findings] [[📄 paper](https://arxiv.org/abs/2604.11716)]


### PR DESCRIPTION
## Summary

Add *Function-Aware Fill-in-the-Middle as Mid-Training for Coding Agent Foundation Models* to Repo-Level Issue Resolution.

The work trains coding-agent foundation models with function-aware FIM mid-training and evaluates the resulting post-trained agents on repository-level issue resolution. The entry follows the list's existing date, paper, and repository format.

## Checks

- Searched the default branch and complete issue/pull-request history for the title, arXiv ID, and canonical repository; no equivalent entry was found.
- Verified the canonical paper and repository links.
- Ran `git diff --check`.

Disclosure: submitted on behalf of FIM-Midtraining co-author Yuxuan Zhang.
